### PR TITLE
DPS-6378: Migrate ghcr.io/oviva-ag image refs to europe-docker.pkg.dev/oviva-pkg/ovi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           token_format: access_token
-          workload_identity_provider: projects/155692196363/locations/global/workloadIdentityPools/github-actions-sa/providers/github-actions-sa
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: gh-wi-main-registry-writer@github-actions-sa.iam.gserviceaccount.com
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,13 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: europe-docker.pkg.dev
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - name: Setup Java
@@ -29,12 +28,13 @@ jobs:
           echo "parsing version from ref '$GITHUB_REF'"
           VERSION=$(echo "$GITHUB_REF" | sed -e 's|.*/v\(.*\)|\1|g')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Configure Docker for GAR
+        run: gcloud auth configure-docker europe-docker.pkg.dev --quiet
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - id: buildx
@@ -57,6 +57,6 @@ jobs:
         with:
           name: ${{ steps.version.outputs.version }}
           body: |
-            Docker image: `ghcr.io/oviva-ag/konnektor-watchdog:v${{ steps.version.outputs.version }}`
+            Docker image: `europe-docker.pkg.dev/oviva-pkg/ovi/konnektor-watchdog:v${{ steps.version.outputs.version }}`
           files: |
             target/konnektor-watchdog.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Setup Java
@@ -29,12 +30,18 @@ jobs:
           VERSION=$(echo "$GITHUB_REF" | sed -e 's|.*/v\(.*\)|\1|g')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        id: auth
+        uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Configure Docker for GAR
-        run: gcloud auth configure-docker europe-docker.pkg.dev --quiet
+          token_format: access_token
+          workload_identity_provider: projects/155692196363/locations/global/workloadIdentityPools/github-actions-sa/providers/github-actions-sa
+          service_account: gh-wi-main-registry-writer@github-actions-sa.iam.gserviceaccount.com
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - id: buildx

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MVN=./mvnw
 
-VERSION?=$(shell $(MVN) -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+VERSION?=$(shell $(MVN) -q -Dexec.executable=echo -Dexec.args='$${project.version}' --non-recursive exec:exec)
 
 DOCKER_REPO=europe-docker.pkg.dev/oviva-pkg/ovi/
 IMAGE_NAME=konnektor-watchdog

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-
 MVN=./mvnw
 
-VERSION?=$(shell $(MVN) -q -Dexec.executable=echo -Dexec.args='$${project.version}' --non-recursive exec:exec)
+VERSION?=$(shell $(MVN) -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
 
-DOCKER_REPO=ghcr.io/oviva-ag/
+DOCKER_REPO=europe-docker.pkg.dev/oviva-pkg/ovi/
 IMAGE_NAME=konnektor-watchdog
 
 GIT_COMMIT=`git rev-parse HEAD`


### PR DESCRIPTION
## What
Replace `ghcr.io/oviva-ag/*` image references with `europe-docker.pkg.dev/oviva-pkg/ovi/*`. Swap release workflow auth from GHCR token to GCP Workload Identity.

## Why
Consolidate to single registry; remove split auth paths; align with org standard.

## Jira
DPS-6378